### PR TITLE
Add Magento setup script and Docker configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+src/vendor/
+src/var/
+src/pub/static/
+src/generated/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM php:8.2-apache
+
+# Install system dependencies and PHP extensions required by Magento
+RUN apt-get update && \
+    apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libpng-dev libzip-dev unzip git && \
+    docker-php-ext-configure gd --with-freetype --with-jpeg && \
+    docker-php-ext-install pdo_mysql gd intl bcmath opcache zip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www/html
+
+# Copy source after composer to leverage docker cache in real setup
+COPY src/ /var/www/html
+
+# Set recommended PHP settings for Magento
+RUN { \
+    echo 'memory_limit=2G'; \
+    echo 'max_execution_time=1800'; \
+    echo 'zlib.output_compression=On'; \
+} > /usr/local/etc/php/conf.d/magento.ini
+
+EXPOSE 80
+CMD ["apache2-foreground"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Magento 2 Docker Setup
+
+This repository contains a minimal setup script and Docker configuration for running Magento 2 Open Source with sample data. These instructions assume you have Docker and Docker Compose installed and internet access to download Magento packages and container images.
+
+## Requirements
+
+- Docker & Docker Compose
+- Magento repository access keys (for Composer authentication)
+
+## Setup Steps
+
+1. Add your Magento authentication keys to `~/.composer/auth.json` as shown in [Magento docs](https://devdocs.magento.com/guides/v2.4/install-gde/prereq/connect-auth.html).
+2. Run `./setup_magento.sh` to download Magento 2, deploy sample data and perform the initial installation. This step requires internet access.
+3. Start the containers with `docker compose up -d`.
+4. Access the storefront at `http://localhost` and the admin at `http://localhost/admin`.
+
+## Files
+
+- `setup_magento.sh` – Script to install Magento 2 with sample data into the `src/` directory.
+- `docker-compose.yml` – Defines the PHP web container and a MariaDB database.
+- `Dockerfile` – Builds a PHP 8.2 environment with required extensions and Composer.
+
+Make sure to run these steps on a machine with network connectivity, as the containers and Magento packages need to be downloaded.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.9'
+
+services:
+  app:
+    build: .
+    volumes:
+      - ./src:/var/www/html
+    ports:
+      - "80:80"
+    depends_on:
+      - db
+
+  db:
+    image: mariadb:10.6
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: magento
+      MYSQL_USER: magento
+      MYSQL_PASSWORD: magento
+    volumes:
+      - db-data:/var/lib/mysql
+
+volumes:
+  db-data:

--- a/setup_magento.sh
+++ b/setup_magento.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+# Directory where Magento will be installed
+MAGENTO_DIR="src"
+
+if [ ! -d "$MAGENTO_DIR" ]; then
+  mkdir "$MAGENTO_DIR"
+fi
+
+# Check for composer
+if ! command -v composer >/dev/null 2>&1; then
+  echo "Composer is required but not installed. Install Composer and rerun this script." >&2
+  exit 1
+fi
+
+# Check for Magento authentication
+if [ ! -f "$HOME/.composer/auth.json" ]; then
+  cat >&2 <<EOE
+Magento authentication keys not found.
+Create \$HOME/.composer/auth.json with your repo.magento.com credentials as described in the Magento documentation.
+EOE
+  exit 1
+fi
+
+# Download Magento if not present
+if [ ! -f "$MAGENTO_DIR/bin/magento" ]; then
+  composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition "$MAGENTO_DIR"
+fi
+
+cd "$MAGENTO_DIR"
+
+# Deploy sample data
+php bin/magento sampledata:deploy
+
+# Install Magento
+php bin/magento setup:install \
+  --base-url=http://localhost \
+  --db-host=db \
+  --db-name=magento \
+  --db-user=magento \
+  --db-password=magento \
+  --backend-frontname=admin \
+  --admin-firstname=Admin \
+  --admin-lastname=User \
+  --admin-email=admin@example.com \
+  --admin-user=admin \
+  --admin-password=Admin123 \
+  --language=en_US \
+  --currency=USD \
+  --timezone=UTC \
+  --use-rewrites=1


### PR DESCRIPTION
## Summary
- add instructions for Magento installation
- add Dockerfile and docker-compose for Magento
- add setup script to download Magento and sample data
- ignore build artifacts

## Testing
- `./setup_magento.sh` *(fails: Composer is required but not installed)*
- `docker compose up -d` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68561dadc9888333b4d595961870f5d5