### PR TITLE
Add basic Category Sales Report module

### DIFF
--- a/app/code/Biz/CategorySalesReport/Controller/Adminhtml/Report/Export.php
+++ b/app/code/Biz/CategorySalesReport/Controller/Adminhtml/Report/Export.php
@@ -1,0 +1,54 @@
+<?php
+namespace Biz\CategorySalesReport\Controller\Adminhtml\Report;
+
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Biz\CategorySalesReport\Model\ReportGenerator;
+use Magento\Framework\Filesystem\DirectoryList;
+use Magento\Framework\Serialize\SerializerInterface;
+
+class Export extends Action
+{
+    const ADMIN_RESOURCE = 'Biz_CategorySalesReport::report';
+
+    protected $fileFactory;
+    protected $reportGenerator;
+    protected $directoryList;
+    protected $serializer;
+
+    public function __construct(
+        Context $context,
+        FileFactory $fileFactory,
+        ReportGenerator $reportGenerator,
+        DirectoryList $directoryList,
+        SerializerInterface $serializer
+    ) {
+        parent::__construct($context);
+        $this->fileFactory = $fileFactory;
+        $this->reportGenerator = $reportGenerator;
+        $this->directoryList = $directoryList;
+        $this->serializer = $serializer;
+    }
+
+    public function execute()
+    {
+        $categoryIds = $this->getRequest()->getParam('categories', []);
+        $from = $this->getRequest()->getParam('from');
+        $to = $this->getRequest()->getParam('to');
+
+        $data = $this->reportGenerator->generate($categoryIds, $from, $to);
+
+        $csv = "sku,name,qty,total\n";
+        foreach ($data as $row) {
+            $csv .= sprintf("%s,%s,%s,%s\n", $row['sku'], $row['name'], $row['qty'], $row['total']);
+        }
+
+        return $this->fileFactory->create(
+            'category_sales_report.csv',
+            $csv,
+            DirectoryList::VAR_DIR,
+            'text/csv'
+        );
+    }
+}

--- a/app/code/Biz/CategorySalesReport/Controller/Adminhtml/Report/Index.php
+++ b/app/code/Biz/CategorySalesReport/Controller/Adminhtml/Report/Index.php
@@ -1,0 +1,27 @@
+<?php
+namespace Biz\CategorySalesReport\Controller\Adminhtml\Report;
+
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\View\Result\PageFactory;
+
+class Index extends Action
+{
+    const ADMIN_RESOURCE = 'Biz_CategorySalesReport::report';
+
+    protected $resultPageFactory;
+
+    public function __construct(Context $context, PageFactory $resultPageFactory)
+    {
+        parent::__construct($context);
+        $this->resultPageFactory = $resultPageFactory;
+    }
+
+    public function execute()
+    {
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->setActiveMenu('Biz_CategorySalesReport::report');
+        $resultPage->getConfig()->getTitle()->prepend(__('Category Sales Report'));
+        return $resultPage;
+    }
+}

--- a/app/code/Biz/CategorySalesReport/Model/ReportGenerator.php
+++ b/app/code/Biz/CategorySalesReport/Model/ReportGenerator.php
@@ -1,0 +1,51 @@
+<?php
+namespace Biz\CategorySalesReport\Model;
+
+use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Sales\Model\ResourceModel\Order\Item\CollectionFactory as OrderItemCollectionFactory;
+use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
+
+class ReportGenerator
+{
+    protected $categoryRepository;
+    protected $orderItemCollectionFactory;
+    protected $categoryCollectionFactory;
+
+    public function __construct(
+        CategoryRepositoryInterface $categoryRepository,
+        OrderItemCollectionFactory $orderItemCollectionFactory,
+        CategoryCollectionFactory $categoryCollectionFactory
+    ) {
+        $this->categoryRepository = $categoryRepository;
+        $this->orderItemCollectionFactory = $orderItemCollectionFactory;
+        $this->categoryCollectionFactory = $categoryCollectionFactory;
+    }
+
+    /**
+     * Generate report data.
+     *
+     * @param array $categoryIds
+     * @param string $from
+     * @param string $to
+     * @return array
+     */
+    public function generate(array $categoryIds, $from, $to)
+    {
+        // This is a simplified placeholder implementation. In a real environment
+        // you would join category and order tables to fetch aggregated results.
+        $collection = $this->orderItemCollectionFactory->create();
+        $collection->addFieldToFilter('created_at', ['from' => $from, 'to' => $to]);
+        $collection->addFieldToFilter('product_type', ['neq' => 'configurable']);
+
+        $data = [];
+        foreach ($collection as $item) {
+            $sku = $item->getSku();
+            $data[$sku]['sku'] = $sku;
+            $data[$sku]['name'] = $item->getName();
+            $data[$sku]['qty'] = ($data[$sku]['qty'] ?? 0) + $item->getQtyOrdered();
+            $data[$sku]['total'] = ($data[$sku]['total'] ?? 0) + $item->getRowTotal();
+        }
+
+        return $data;
+    }
+}

--- a/app/code/Biz/CategorySalesReport/etc/acl.xml
+++ b/app/code/Biz/CategorySalesReport/etc/acl.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<acl xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <resources>
+        <resource id="Magento_Backend::admin">
+            <resource id="Magento_Backend::report">
+                <resource id="Biz_CategorySalesReport::report" title="Category Sales Report" />
+            </resource>
+        </resource>
+    </resources>
+</acl>

--- a/app/code/Biz/CategorySalesReport/etc/adminhtml/menu.xml
+++ b/app/code/Biz/CategorySalesReport/etc/adminhtml/menu.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/etc/menu.xsd">
+    <menu>
+        <add id="Biz_CategorySalesReport::report" title="Category Sales Report" module="Biz_CategorySalesReport" sortOrder="10" parent="Magento_Backend::reports" resource="Biz_CategorySalesReport::report"/>
+    </menu>
+</config>

--- a/app/code/Biz/CategorySalesReport/etc/adminhtml/routes.xml
+++ b/app/code/Biz/CategorySalesReport/etc/adminhtml/routes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="admin">
+        <route id="categorysalesreport" frontName="categorysalesreport">
+            <module name="Biz_CategorySalesReport"/>
+        </route>
+    </router>
+</config>

--- a/app/code/Biz/CategorySalesReport/etc/di.xml
+++ b/app/code/Biz/CategorySalesReport/etc/di.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+</config>

--- a/app/code/Biz/CategorySalesReport/etc/module.xml
+++ b/app/code/Biz/CategorySalesReport/etc/module.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Biz_CategorySalesReport" setup_version="1.0.0"/>
+</config>

--- a/app/code/Biz/CategorySalesReport/registration.php
+++ b/app/code/Biz/CategorySalesReport/registration.php
@@ -1,0 +1,6 @@
+<?php
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'Biz_CategorySalesReport',
+    __DIR__
+);

--- a/app/code/Biz/CategorySalesReport/view/adminhtml/layout/categorysalesreport_report_index.xml
+++ b/app/code/Biz/CategorySalesReport/view/adminhtml/layout/categorysalesreport_report_index.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="category_sales_report_form" />
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/Biz/CategorySalesReport/view/adminhtml/ui_component/category_sales_report_form.xml
+++ b/app/code/Biz/CategorySalesReport/view/adminhtml/ui_component/category_sales_report_form.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">category_sales_report_form.category_sales_report_form_data_source</item>
+            <item name="deps" xsi:type="string">category_sales_report_form.category_sales_report_form_data_source</item>
+        </item>
+        <item name="label" xsi:type="string" translate="true">Category Sales Report</item>
+    </argument>
+    <dataSource name="category_sales_report_form_data_source">
+        <argument name="dataProvider" xsi:type="configurableObject">
+            <argument name="class" xsi:type="string">Magento\Ui\Component\Form\DataProvider</argument>
+            <argument name="name" xsi:type="string">category_sales_report_form_data_source</argument>
+            <argument name="primaryFieldName" xsi:type="string">id</argument>
+            <argument name="requestFieldName" xsi:type="string">id</argument>
+        </argument>
+    </dataSource>
+    <fieldset name="general">
+        <field name="categories" sortOrder="10" formElement="multiselect">
+            <settings>
+                <label translate="true">Categories</label>
+                <component>Magento_Catalog/js/components/category-select-tree</component>
+                <filter_by_parent>true</filter_by_parent>
+                <levels>2</levels>
+                <multiple>true</multiple>
+                <required>true</required>
+            </settings>
+        </field>
+        <field name="from" sortOrder="20" formElement="date">
+            <settings>
+                <label translate="true">From</label>
+                <dataType>date</dataType>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+        </field>
+        <field name="to" sortOrder="30" formElement="date">
+            <settings>
+                <label translate="true">To</label>
+                <dataType>date</dataType>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+        </field>
+        <button name="export" sortOrder="40" displayAsLink="false" class="primary" formElement="container">
+            <settings>
+                <label translate="true">Export</label>
+                <actions>
+                    <action type="submit">
+                        <argument name="url" xsi:type="string">categorysalesreport/report/export</argument>
+                    </action>
+                </actions>
+            </settings>
+        </button>
+    </fieldset>
+</form>


### PR DESCRIPTION
## Summary
- create `Biz_CategorySalesReport` module skeleton for Magento 2
- add admin menu item and ACL configuration
- implement controllers for report UI and CSV export
- add placeholder report generator model
- include admin layout and UI component form

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfd9dc0088333bdce75aba6b8fd3b